### PR TITLE
fix: allow deselecting color in notes label modal by toggling select state

### DIFF
--- a/src/components/Messages/NotesLabelsModal.tsx
+++ b/src/components/Messages/NotesLabelsModal.tsx
@@ -303,7 +303,7 @@ export default function NotesLabelsModal(props: {
                     <IconButton
                       key={c.color}
                       variant={selectedColor === c.color ? "soft" : "plain"}
-                      onClick={() => setSelectedColor(c.color)}
+                      onClick={() => setSelectedColor(selectedColor === c.color ? null : c.color)}
                       sx={{
                         width: 28,
                         height: 28,


### PR DESCRIPTION
Fixes on clicking the color panel in the labels modal